### PR TITLE
Bug/persistent org login

### DIFF
--- a/mrbelvedereci/cumulusci/models.py
+++ b/mrbelvedereci/cumulusci/models.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from cumulusci.core.config import ScratchOrgConfig
+from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import ScratchOrgException
 from django.db import models
 from django.urls import reverse
@@ -23,6 +24,11 @@ class Org(models.Model):
 
     def get_absolute_url(self):
         return reverse('org_detail', kwargs={'org_id': self.id})
+
+    def get_org_config(self):
+        org_config = json.loads(self.json)
+
+        return OrgConfig(org_config)
     
 class ScratchOrgInstance(models.Model):
     org = models.ForeignKey('cumulusci.Org', related_name='instances')

--- a/mrbelvedereci/cumulusci/templates/cumulusci/org_detail.html
+++ b/mrbelvedereci/cumulusci/templates/cumulusci/org_detail.html
@@ -26,7 +26,7 @@
 {% endblock %}
 
 {% block layout_header_buttons %}
-      <a href="{{ instance.get_absolute_url }}/login" target="_blank">
+      <a href="{{ org.get_absolute_url }}/login" target="_blank">
         <button class="slds-button slds-button--brand">
           Log In
         </button>

--- a/mrbelvedereci/cumulusci/templates/cumulusci/org_detail.html
+++ b/mrbelvedereci/cumulusci/templates/cumulusci/org_detail.html
@@ -26,11 +26,13 @@
 {% endblock %}
 
 {% block layout_header_buttons %}
+{% if not org.scratch %}
       <a href="{{ org.get_absolute_url }}/login" target="_blank">
         <button class="slds-button slds-button--brand">
           Log In
         </button>
       </a>
+      {% endif %}
 {% endblock %}
 
 {% block layout_body %}

--- a/mrbelvedereci/cumulusci/urls.py
+++ b/mrbelvedereci/cumulusci/urls.py
@@ -3,7 +3,7 @@ from mrbelvedereci.cumulusci import views
 
 urlpatterns = [
     url(r'^/(?P<org_id>\d+)$', views.org_detail, name="org_detail"),
-    url(r'^/(?P<org_id>\d+)/login$', views.org_detail, name="org_login"),
+    url(r'^/(?P<org_id>\d+)/login$', views.org_login, name="org_login"),
     url(r'^/(?P<org_id>\d+)/(?P<instance_id>\d+)/login$', views.org_login, name="org_instance_login"),
     url(r'^/(?P<org_id>\d+)/(?P<instance_id>\d+)/delete$', views.org_instance_delete, name="org_instance_delete"),
     url(r'^/(?P<org_id>\d+)/(?P<instance_id>\d+)$', views.org_instance_detail, name="org_instance_detail"),


### PR DESCRIPTION
the login button on the org detail page was set to go to an incorrect route. 

login button now only shows on persistent org detail (scratch org instances have login on the instance detail) and it works.