### PR TITLE
Add ability for users to delete their notifications

### DIFF
--- a/mrbelvedereci/notification/forms.py
+++ b/mrbelvedereci/notification/forms.py
@@ -118,11 +118,6 @@ class DeleteNotificationForm(forms.Form):
         self.helper.form_id = 'delete-notification-form'
         self.helper.form_method = 'post'
         self.helper.layout = Layout(
-            HTML(
-                '<div class="slds-text-body--regular">' +
-                'Are you sure you want to delete this notification?' +
-                '</div>',
-            ),
             FormActions(
                 Submit(
                     'action',

--- a/mrbelvedereci/notification/forms.py
+++ b/mrbelvedereci/notification/forms.py
@@ -4,6 +4,7 @@ from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Field
 from crispy_forms.layout import Fieldset
+from crispy_forms.layout import HTML
 from crispy_forms.layout import Layout
 from crispy_forms.layout import Submit
 from django import forms
@@ -117,9 +118,10 @@ class DeleteNotificationForm(forms.Form):
         self.helper.form_id = 'delete-notification-form'
         self.helper.form_method = 'post'
         self.helper.layout = Layout(
-            Fieldset(
-                'Are you sure you want to delete this notification?',
-                css_class='slds-form-element',
+            HTML(
+                '<div class="slds-text-body--regular">' +
+                'Are you sure you want to delete this notification?' +
+                '</div>',
             ),
             FormActions(
                 Submit(

--- a/mrbelvedereci/notification/forms.py
+++ b/mrbelvedereci/notification/forms.py
@@ -2,16 +2,13 @@ from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Field
 from crispy_forms.layout import Fieldset
-from crispy_forms.layout import HTML
 from crispy_forms.layout import Layout
 from crispy_forms.layout import Submit
 from django import forms
-from django.conf import settings
-from github3 import login
 
-from mrbelvedereci.notification.models import RepositoryNotification
 from mrbelvedereci.notification.models import BranchNotification
 from mrbelvedereci.notification.models import PlanNotification
+from mrbelvedereci.notification.models import RepositoryNotification
 
 
 class AddRepositoryNotificationForm(forms.ModelForm):

--- a/mrbelvedereci/notification/forms.py
+++ b/mrbelvedereci/notification/forms.py
@@ -1,5 +1,3 @@
-from github3 import login
-
 from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Field
@@ -9,11 +7,15 @@ from crispy_forms.layout import Layout
 from crispy_forms.layout import Submit
 from django import forms
 from django.conf import settings
+from github3 import login
+
 from mrbelvedereci.notification.models import RepositoryNotification
 from mrbelvedereci.notification.models import BranchNotification
 from mrbelvedereci.notification.models import PlanNotification
 
+
 class AddRepositoryNotificationForm(forms.ModelForm):
+
     def __init__(self, *args, **kwargs):
         super(AddRepositoryNotificationForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
@@ -35,17 +37,22 @@ class AddRepositoryNotificationForm(forms.ModelForm):
                 css_class='slds-form-element',
             ),
             FormActions(
-                Submit('submit', 'Submit',
-                       css_class='slds-button slds-button--brand')
+                Submit(
+                    'submit',
+                    'Submit',
+                    css_class='slds-button slds-button--brand',
+                ),
             ),
         )
 
     class Meta:
         model = RepositoryNotification
-        fields = ['repo','user','on_success','on_fail','on_error']
+        fields = ['repo', 'user', 'on_success', 'on_fail', 'on_error']
         widgets = {'user': forms.HiddenInput()}
 
+
 class AddBranchNotificationForm(forms.ModelForm):
+
     def __init__(self, *args, **kwargs):
         super(AddBranchNotificationForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
@@ -67,17 +74,22 @@ class AddBranchNotificationForm(forms.ModelForm):
                 css_class='slds-form-element',
             ),
             FormActions(
-                Submit('submit', 'Submit',
-                       css_class='slds-button slds-button--brand')
+                Submit(
+                    'submit',
+                    'Submit',
+                    css_class='slds-button slds-button--brand',
+                ),
             ),
         )
 
     class Meta:
         model = BranchNotification
-        fields = ['branch','user','on_success','on_fail','on_error']
+        fields = ['branch', 'user', 'on_success', 'on_fail', 'on_error']
         widgets = {'user': forms.HiddenInput()}
 
+
 class AddPlanNotificationForm(forms.ModelForm):
+
     def __init__(self, *args, **kwargs):
         super(AddPlanNotificationForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
@@ -99,18 +111,22 @@ class AddPlanNotificationForm(forms.ModelForm):
                 css_class='slds-form-element',
             ),
             FormActions(
-                Submit('submit', 'Submit',
-                       css_class='slds-button slds-button--brand')
+                Submit(
+                    'submit',
+                    'Submit',
+                    css_class='slds-button slds-button--brand',
+                ),
             ),
         )
 
     class Meta:
         model = PlanNotification
-        fields = ['plan','user','on_success','on_fail','on_error']
+        fields = ['plan', 'user', 'on_success', 'on_fail', 'on_error']
         widgets = {'user': forms.HiddenInput()}
 
 
 class DeleteNotificationForm(forms.Form):
+
     def __init__(self, *args, **kwargs):
         super(DeleteNotificationForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()

--- a/mrbelvedereci/notification/forms.py
+++ b/mrbelvedereci/notification/forms.py
@@ -108,3 +108,29 @@ class AddPlanNotificationForm(forms.ModelForm):
         fields = ['plan','user','on_success','on_fail','on_error']
         widgets = {'user': forms.HiddenInput()}
 
+
+class DeleteNotificationForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        super(DeleteNotificationForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_class = 'form-vertical'
+        self.helper.form_id = 'delete-notification-form'
+        self.helper.form_method = 'post'
+        self.helper.layout = Layout(
+            Fieldset(
+                'Are you sure you want to delete this notification?',
+                css_class='slds-form-element',
+            ),
+            FormActions(
+                Submit(
+                    'action',
+                    'Cancel',
+                    css_class='slds-button slds-button--neutral',
+                ),
+                Submit(
+                    'action',
+                    'Delete',
+                    css_class='slds-button slds-button--destructive',
+                ),
+            ),
+        )

--- a/mrbelvedereci/notification/templates/notification/delete_notification.html
+++ b/mrbelvedereci/notification/templates/notification/delete_notification.html
@@ -6,11 +6,10 @@
 
 {% block layout_body %}
 
-<h3 class="slds-text-heading--medium">
+<h3 class="slds-text-heading--medium slds-m-bottom--medium">
   Are you sure you want to delete this {{ notification_type }} Notification?
 </h3>
-<br/>
-<div class="slds-box">
+<div class="slds-box slds-m-bottom--medium">
   <table class="slds-table slds-no-row-hover">
     <thead>
       <tr>
@@ -43,7 +42,6 @@
     </tbody>
   </table>
 </div>
-<br/>
 
     {{ form.errors }}
       {% crispy form form.helper %}

--- a/mrbelvedereci/notification/templates/notification/delete_notification.html
+++ b/mrbelvedereci/notification/templates/notification/delete_notification.html
@@ -6,6 +6,45 @@
 
 {% block layout_body %}
 
+<h3 class="slds-text-heading--medium">
+  Are you sure you want to delete this {{ notification_type }} Notification?
+</h3>
+<br/>
+<div class="slds-box">
+  <table class="slds-table slds-no-row-hover">
+    <thead>
+      <tr>
+        {% if notification_type == "Branch" %}
+          <th>Branch</th>
+        {% elif notification_type == "Plan" %}
+          <th>Plan</th>
+        {% endif %}
+        <th>Repository</th>
+        <th>On Success</th>
+        <th>On Failure</th>
+        <th>On Error</th>
+      </tr>
+    </thead>
+    <tbody>
+    <tr>
+      {% if notification_type == "Branch" %}
+        <th>{{ notification.branch }}</th>
+        <th>{{ notification.branch.repo }}</th>
+      {% elif notification_type == "Plan" %}
+        <th>{{ notification.plan }}</th>
+        <th>{{ notification.plan.repo }}</th>
+      {% elif notification_type == "Repository" %}
+        <td>{{ notification.repo }}</td>
+      {% endif %}
+      <td>{{ notification.on_success }}</td>
+      <td>{{ notification.on_fail }}</td>
+      <td>{{ notification.on_error }}</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+<br/>
+
     {{ form.errors }}
       {% crispy form form.helper %}
 

--- a/mrbelvedereci/notification/templates/notification/delete_notification.html
+++ b/mrbelvedereci/notification/templates/notification/delete_notification.html
@@ -1,0 +1,12 @@
+{% extends 'layout_full.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block layout_header_text %}Delete Notification{% endblock %}
+
+{% block layout_body %}
+
+    {{ form.errors }}
+      {% crispy form form.helper %}
+
+{% endblock %}

--- a/mrbelvedereci/notification/templates/notification/my_notifications.html
+++ b/mrbelvedereci/notification/templates/notification/my_notifications.html
@@ -52,7 +52,7 @@
     <thead>
       <tr>
         <th>Plan</th>
-        <th>Repo</th>
+        <th>Repository</th>
         <th>On Success</th>
         <th>On Failure</th>
         <th>On Error</th>
@@ -92,7 +92,7 @@
     <thead>
       <tr>
         <th>Branch</th>
-        <th>Repo</th>
+        <th>Repository</th>
         <th>On Success</th>
         <th>On Failure</th>
         <th>On Error</th>

--- a/mrbelvedereci/notification/templates/notification/my_notifications.html
+++ b/mrbelvedereci/notification/templates/notification/my_notifications.html
@@ -26,7 +26,18 @@
         <td>{{ notification.on_success }}</td>
         <td>{{ notification.on_fail }}</td>
         <td>{{ notification.on_error }}</td>
-        <td><a class="slds-button--destructive" href="/notifications/delete/repository/{{ notification.id }}">Delete</a></td>
+        <td>
+          <a href="/notifications/delete/repository/{{ notification.id }}">
+            <button class="slds-button slds-button_icon" title="Delete notification">
+              {% autoescape off %}
+              <svg class="slds-button__icon slds-theme--default" aria-hidden="true">
+                <use xlink:href="/static/slds/assets/icons/action-sprite/svg/symbols.svg#delete"></use>
+              </svg>
+              {% endautoescape %}
+              <span class="slds-assistive-text">Delete notification</span>
+            </button>
+          </a>
+        </td>
       </tr>
     {% endfor %}
     </tbody>
@@ -56,7 +67,18 @@
         <td>{{ notification.on_success }}</td>
         <td>{{ notification.on_fail }}</td>
         <td>{{ notification.on_error }}</td>
-        <td><a class="slds-button--destructive" href="/notifications/delete/plan/{{ notification.id }}">Delete</a></td>
+        <td>
+          <a href="/notifications/delete/plan/{{ notification.id }}">
+            <button class="slds-button slds-button_icon" title="Delete notification">
+              {% autoescape off %}
+              <svg class="slds-button__icon slds-theme--default" aria-hidden="true">
+                <use xlink:href="/static/slds/assets/icons/action-sprite/svg/symbols.svg#delete"></use>
+              </svg>
+              {% endautoescape %}
+              <span class="slds-assistive-text">Delete notification</span>
+            </button>
+          </a>
+        </td>
       </tr>
     {% endfor %}
     </tbody>
@@ -85,7 +107,18 @@
         <td>{{ notification.on_success }}</td>
         <td>{{ notification.on_fail }}</td>
         <td>{{ notification.on_error }}</td>
-        <td><a class="slds-button--destructive" href="/notifications/delete/branch/{{ notification.id }}">Delete</a></td>
+        <td>
+          <a href="/notifications/delete/branch/{{ notification.id }}">
+            <button class="slds-button slds-button_icon" title="Delete notification">
+              {% autoescape off %}
+              <svg class="slds-button__icon slds-theme--default" aria-hidden="true">
+                <use xlink:href="/static/slds/assets/icons/action-sprite/svg/symbols.svg#delete"></use>
+              </svg>
+              {% endautoescape %}
+              <span class="slds-assistive-text">Delete notification</span>
+            </button>
+          </a>
+        </td>
       </tr>
     {% endfor %}
     </tbody>

--- a/mrbelvedereci/notification/templates/notification/my_notifications.html
+++ b/mrbelvedereci/notification/templates/notification/my_notifications.html
@@ -16,6 +16,7 @@
         <th>On Success</th>
         <th>On Failure</th>
         <th>On Error</th>
+        <th>Delete</th>
       </tr>
     </thead>
     <tbody>
@@ -25,6 +26,7 @@
         <td>{{ notification.on_success }}</td>
         <td>{{ notification.on_fail }}</td>
         <td>{{ notification.on_error }}</td>
+        <td><a class="slds-button--destructive" href="/notifications/delete/repository/{{ notification.id }}">Delete</a></td>
       </tr>
     {% endfor %}
     </tbody>
@@ -43,6 +45,7 @@
         <th>On Success</th>
         <th>On Failure</th>
         <th>On Error</th>
+        <th>Delete</th>
       </tr>
     </thead>
     <tbody>
@@ -53,6 +56,7 @@
         <td>{{ notification.on_success }}</td>
         <td>{{ notification.on_fail }}</td>
         <td>{{ notification.on_error }}</td>
+        <td><a class="slds-button--destructive" href="/notifications/delete/plan/{{ notification.id }}">Delete</a></td>
       </tr>
     {% endfor %}
     </tbody>
@@ -70,6 +74,7 @@
         <th>On Success</th>
         <th>On Failure</th>
         <th>On Error</th>
+        <th>Delete</th>
       </tr>
     </thead>
     <tbody>
@@ -80,6 +85,7 @@
         <td>{{ notification.on_success }}</td>
         <td>{{ notification.on_fail }}</td>
         <td>{{ notification.on_error }}</td>
+        <td><a class="slds-button--destructive" href="/notifications/delete/branch/{{ notification.id }}">Delete</a></td>
       </tr>
     {% endfor %}
     </tbody>

--- a/mrbelvedereci/notification/urls.py
+++ b/mrbelvedereci/notification/urls.py
@@ -22,4 +22,19 @@ urlpatterns = [
         views.add_plan_notification,
         name='add_plan_notification',
     ),
+    url(
+        r'^/delete/branch/(?P<pk>\d+)$',
+        views.delete_branch_notification,
+        name='delete_branch_notification',
+    ),
+    url(
+        r'^/delete/plan/(?P<pk>\d+)$',
+        views.delete_plan_notification,
+        name='delete_plan_notification',
+    ),
+    url(
+        r'^/delete/repository/(?P<pk>\d+)$',
+        views.delete_repository_notification,
+        name='delete_repository_notification',
+    ),
 ]

--- a/mrbelvedereci/notification/urls.py
+++ b/mrbelvedereci/notification/urls.py
@@ -2,8 +2,24 @@ from django.conf.urls import url
 from mrbelvedereci.notification import views
 
 urlpatterns = [
-    url(r'^$', views.my_notifications, name="my_notifications"),
-    url(r'^/add/repository', views.add_repository_notification, name="add_repository_notification"),
-    url(r'^/add/branch', views.add_branch_notification, name="add_branch_notification"),
-    url(r'^/add/plan', views.add_plan_notification, name="add_plan_notification"),
+    url(
+        r'^$',
+        views.my_notifications,
+        name='my_notifications',
+    ),
+    url(
+        r'^/add/repository',
+        views.add_repository_notification,
+        name='add_repository_notification',
+    ),
+    url(
+        r'^/add/branch',
+        views.add_branch_notification,
+        name='add_branch_notification',
+    ),
+    url(
+        r'^/add/plan',
+        views.add_plan_notification,
+        name='add_plan_notification',
+    ),
 ]

--- a/mrbelvedereci/notification/views.py
+++ b/mrbelvedereci/notification/views.py
@@ -1,11 +1,11 @@
-from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
-from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
 
-from mrbelvedereci.notification.forms import AddRepositoryNotificationForm
 from mrbelvedereci.notification.forms import AddBranchNotificationForm
 from mrbelvedereci.notification.forms import AddPlanNotificationForm
+from mrbelvedereci.notification.forms import AddRepositoryNotificationForm
 from mrbelvedereci.notification.forms import DeleteNotificationForm
 from mrbelvedereci.notification.models import BranchNotification
 from mrbelvedereci.notification.models import PlanNotification

--- a/mrbelvedereci/notification/views.py
+++ b/mrbelvedereci/notification/views.py
@@ -103,5 +103,12 @@ def delete_notification(request, o):
     return render(
         request,
         'notification/delete_notification.html',
-        context={'form': form},
+        context={
+            'form': form,
+            'notification': o,
+            'notification_type': o.__class__.__name__.replace(
+                'Notification',
+                '',
+            ),
+        },
     )

--- a/mrbelvedereci/notification/views.py
+++ b/mrbelvedereci/notification/views.py
@@ -19,12 +19,12 @@ def my_notifications(request):
         'repo': request.user.repo_notifications.all(),
         'branch': request.user.branch_notifications.all(),
     }
+    return render(
+        request,
+        'notification/my_notifications.html',
+        context={'notifications': notifications},
+    )
 
-    context = {
-        'notifications': notifications,
-    }
-
-    return render(request, 'notification/my_notifications.html', context=context)
 
 @login_required
 def add_repository_notification(request):
@@ -36,12 +36,12 @@ def add_repository_notification(request):
             return HttpResponseRedirect('/notifications')
     else:
         form = AddRepositoryNotificationForm(initial=initial)
+    return render(
+        request,
+        'notification/add_repository_notification.html',
+        context={'form': form},
+    )
 
-    context = {
-        'form': form,
-    }
-
-    return render(request, 'notification/add_repository_notification.html', context=context)
 
 @login_required
 def add_branch_notification(request):
@@ -53,12 +53,12 @@ def add_branch_notification(request):
             return HttpResponseRedirect('/notifications')
     else:
         form = AddBranchNotificationForm(initial=initial)
+    return render(
+        request,
+        'notification/add_branch_notification.html',
+        context={'form': form},
+    )
 
-    context = {
-        'form': form,
-    }
-
-    return render(request, 'notification/add_branch_notification.html', context=context)
 
 @login_required
 def add_plan_notification(request):
@@ -70,33 +70,45 @@ def add_plan_notification(request):
             return HttpResponseRedirect('/notifications')
     else:
         form = AddPlanNotificationForm(initial=initial)
+    return render(
+        request,
+        'notification/add_plan_notification.html',
+        context={'form': form},
+    )
 
-    context = {
-        'form': form,
-    }
-
-    return render(request, 'notification/add_plan_notification.html', context=context)
 
 @login_required
 def delete_branch_notification(request, pk):
-    return delete_notification(request, BranchNotification.objects.get(pk=pk))
+    return delete_notification(
+        request,
+        BranchNotification.objects.get(pk=pk),
+    )
+
 
 @login_required
 def delete_plan_notification(request, pk):
-    return delete_notification(request, PlanNotification.objects.get(pk=pk))
+    return delete_notification(
+        request,
+        PlanNotification.objects.get(pk=pk),
+    )
+
 
 @login_required
 def delete_repository_notification(request, pk):
-    return delete_notification(request, RepositoryNotification.objects.get(pk=pk))
+    return delete_notification(
+        request,
+        RepositoryNotification.objects.get(pk=pk),
+    )
 
-def delete_notification(request, o):
-    if request.user != o.user:
+
+def delete_notification(request, notification):
+    if request.user != notification.user:
         return HttpResponseForbidden()
     if request.method == 'POST':
         form = DeleteNotificationForm(request.POST)
         if form.is_valid():
             if request.POST['action'] == 'Delete':
-                o.delete()
+                notification.delete()
             return HttpResponseRedirect('/notifications')
     else:
         form = DeleteNotificationForm()
@@ -105,8 +117,8 @@ def delete_notification(request, o):
         'notification/delete_notification.html',
         context={
             'form': form,
-            'notification': o,
-            'notification_type': o.__class__.__name__.replace(
+            'notification': notification,
+            'notification_type': notification.__class__.__name__.replace(
                 'Notification',
                 '',
             ),

--- a/mrbelvedereci/notification/views.py
+++ b/mrbelvedereci/notification/views.py
@@ -1,9 +1,16 @@
 from django.shortcuts import render
+from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
+
 from mrbelvedereci.notification.forms import AddRepositoryNotificationForm
 from mrbelvedereci.notification.forms import AddBranchNotificationForm
 from mrbelvedereci.notification.forms import AddPlanNotificationForm
+from mrbelvedereci.notification.forms import DeleteNotificationForm
+from mrbelvedereci.notification.models import BranchNotification
+from mrbelvedereci.notification.models import PlanNotification
+from mrbelvedereci.notification.models import RepositoryNotification
+
 
 @login_required
 def my_notifications(request):
@@ -69,3 +76,32 @@ def add_plan_notification(request):
     }
 
     return render(request, 'notification/add_plan_notification.html', context=context)
+
+@login_required
+def delete_branch_notification(request, pk):
+    return delete_notification(request, BranchNotification.objects.get(pk=pk))
+
+@login_required
+def delete_plan_notification(request, pk):
+    return delete_notification(request, PlanNotification.objects.get(pk=pk))
+
+@login_required
+def delete_repository_notification(request, pk):
+    return delete_notification(request, RepositoryNotification.objects.get(pk=pk))
+
+def delete_notification(request, o):
+    if request.user != o.user:
+        return HttpResponseForbidden()
+    if request.method == 'POST':
+        form = DeleteNotificationForm(request.POST)
+        if form.is_valid():
+            if request.POST['action'] == 'Delete':
+                o.delete()
+            return HttpResponseRedirect('/notifications')
+    else:
+        form = DeleteNotificationForm()
+    return render(
+        request,
+        'notification/delete_notification.html',
+        context={'form': form},
+    )


### PR DESCRIPTION
Added "Delete" column at the end with trash can icons:
![screen shot 2017-06-22 at 3 15 47 pm](https://user-images.githubusercontent.com/11445853/27458994-f3fb2a90-5760-11e7-883d-2ddd0496752b.png)

Click on one of the trash cans and you go to a related delete page:
![screen shot 2017-06-22 at 3 16 00 pm](https://user-images.githubusercontent.com/11445853/27458999-f98ea068-5760-11e7-9a91-b570611cd7b8.png)
![screen shot 2017-06-22 at 3 16 10 pm](https://user-images.githubusercontent.com/11445853/27459001-fbd982ca-5760-11e7-8da4-e2de6f103f7c.png)
![screen shot 2017-06-22 at 3 16 17 pm](https://user-images.githubusercontent.com/11445853/27459003-fda971a0-5760-11e7-9545-92633f701771.png)

If you try to delete a notification that does not belong to you (by altering the URL to a different object ID) it will return HTTP Forbidden.