### PR TITLE
test_results.json may contain actual integers

### DIFF
--- a/mrbelvedereci/testresults/importer.py
+++ b/mrbelvedereci/testresults/importer.py
@@ -135,5 +135,10 @@ def get_value_from_stats(stats, field):
         return
 
     value = stats[stats_key][suffix]
-    value = value.replace(' ******* CLOSE TO LIMIT', '')
+    
+    try:
+        value = value.replace(' ******* CLOSE TO LIMIT', '')
+    except AttributeError:
+        pass
+
     return int(value)


### PR DESCRIPTION
debug log based limits usage values are in a string, because they may have the "CLOSE TO LIMIT" text.

however, limit usage values from the tooling API will be a true int. EAFP - try and strip that text but don't worry about it too much.