### PR TITLE
Refresh OAuth token before logging in to org

### DIFF
--- a/mrbelvedereci/cumulusci/keychain.py
+++ b/mrbelvedereci/cumulusci/keychain.py
@@ -1,7 +1,6 @@
 import json
 import os
 from cumulusci.core.keychain import BaseProjectKeychain
-from cumulusci.core.config import ConnectedAppOAuthConfig
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import ServiceConfig
@@ -11,6 +10,7 @@ from mrbelvedereci.cumulusci.logger import init_logger
 from mrbelvedereci.cumulusci.models import Org
 from mrbelvedereci.cumulusci.models import ScratchOrgInstance
 from mrbelvedereci.cumulusci.models import Service
+from mrbelvedereci.cumulusci.utils import get_connected_app
 
 class MrbelvedereProjectKeychain(BaseProjectKeychain):
 
@@ -31,11 +31,7 @@ class MrbelvedereProjectKeychain(BaseProjectKeychain):
         raise NotImplementedError('set_connected_app is not supported in this keychain')
 
     def get_connected_app(self):
-        return ConnectedAppOAuthConfig({
-            'callback_url': settings.CONNECTED_APP_CALLBACK_URL,
-            'client_id': settings.CONNECTED_APP_CLIENT_ID,
-            'client_secret': settings.CONNECTED_APP_CLIENT_SECRET,
-        })
+        return get_connected_app()
 
     def get_service(self, service_name):
         try:

--- a/mrbelvedereci/cumulusci/utils.py
+++ b/mrbelvedereci/cumulusci/utils.py
@@ -1,0 +1,10 @@
+from cumulusci.core.config import ConnectedAppOAuthConfig
+from django.conf import settings
+
+
+def get_connected_app():
+    return ConnectedAppOAuthConfig({
+        'callback_url': settings.CONNECTED_APP_CALLBACK_URL,
+        'client_id': settings.CONNECTED_APP_CLIENT_ID,
+        'client_secret': settings.CONNECTED_APP_CLIENT_SECRET,
+    })

--- a/mrbelvedereci/cumulusci/views.py
+++ b/mrbelvedereci/cumulusci/views.py
@@ -1,5 +1,3 @@
-from cumulusci.core.config import ConnectedAppOAuthConfig
-from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404
@@ -10,6 +8,7 @@ from django.shortcuts import get_object_or_404
 from mrbelvedereci.build.utils import view_queryset
 from mrbelvedereci.cumulusci.models import Org
 from mrbelvedereci.cumulusci.models import ScratchOrgInstance
+from mrbelvedereci.cumulusci.utils import get_connected_app
 
 @staff_member_required
 def org_detail(request, org_id):
@@ -31,11 +30,7 @@ def org_login(request, org_id, instance_id=None):
 
     def get_org_config(org):
         org_config = org.get_org_config()
-        connected_app = ConnectedAppOAuthConfig({
-            'callback_url': settings.CONNECTED_APP_CALLBACK_URL,
-            'client_id': settings.CONNECTED_APP_CLIENT_ID,
-            'client_secret': settings.CONNECTED_APP_CLIENT_SECRET,
-        })
+        connected_app = get_connected_app()
         org_config.refresh_oauth_token(connected_app)
         return org_config
 


### PR DESCRIPTION
It would be nice to use MrbelvedereProjectKeychain to get the connected app info and not duplicate the code here, but it requires a project_config which in turn requires us to be in a build directory to retrieve the project_config. Since the login action could occur after the build dir is long gone, I think we have to do it this way.