### PR TITLE
Updates to tests "compare-to" 

### DIFF
--- a/mrbelvedereci/testresults/filters.py
+++ b/mrbelvedereci/testresults/filters.py
@@ -4,8 +4,10 @@ from mrbelvedereci.build.models import BuildFlow
 
 class BuildFlowFilter(django_filters.FilterSet):
     plan = django_filters.CharFilter(name="build__plan__name", label='Plan Name', lookup_expr='contains')
+    branch = django_filters.CharFilter(name="build__branch__name", label='Branch Name', lookup_expr='contains')
     build = django_filters.CharFilter(name='build')
+    start_date = django_filters.DateFromToRangeFilter(name="build__time_start", label="Date")
 
     class Meta:
         model = BuildFlow
-        fields = ['build','plan']
+        fields = ['build','plan','branch']

--- a/mrbelvedereci/testresults/filters.py
+++ b/mrbelvedereci/testresults/filters.py
@@ -7,7 +7,7 @@ class BuildFlowFilter(django_filters.FilterSet):
     plan = django_filters.CharFilter(name="build__plan__name", label='Plan Name', lookup_expr='contains')
     branch = django_filters.CharFilter(name="build__branch__name", label='Branch Name', lookup_expr='contains')
     build = django_filters.CharFilter(name='build')
-    start_date = django_filters.DateFromToRangeFilter(name="build__time_start", label="Date",widget=RangeWidget(attrs={'placeholder': 'MM/DD/YYYY'}))
+    start_date = django_filters.DateFromToRangeFilter(name="build__time_start", label="Start Date",widget=RangeWidget(attrs={'placeholder': 'MM/DD/YYYY'}))
 
     class Meta:
         model = BuildFlow

--- a/mrbelvedereci/testresults/filters.py
+++ b/mrbelvedereci/testresults/filters.py
@@ -1,4 +1,5 @@
 import django_filters
+from django_filters.widgets import RangeWidget
 
 from mrbelvedereci.build.models import BuildFlow
 
@@ -6,8 +7,8 @@ class BuildFlowFilter(django_filters.FilterSet):
     plan = django_filters.CharFilter(name="build__plan__name", label='Plan Name', lookup_expr='contains')
     branch = django_filters.CharFilter(name="build__branch__name", label='Branch Name', lookup_expr='contains')
     build = django_filters.CharFilter(name='build')
-    start_date = django_filters.DateFromToRangeFilter(name="build__time_start", label="Date")
+    start_date = django_filters.DateFromToRangeFilter(name="build__time_start", label="Date",widget=RangeWidget(attrs={'placeholder': 'MM/DD/YYYY'}))
 
     class Meta:
         model = BuildFlow
-        fields = ['build','plan','branch']
+        fields = ['build','plan','branch','start_date']

--- a/mrbelvedereci/testresults/templates/testresults/build_flow_compare.html
+++ b/mrbelvedereci/testresults/templates/testresults/build_flow_compare.html
@@ -25,7 +25,7 @@ Test Comparison for {{ execution1.build.repo }}
                 <dt class="slds-item--label slds-text-color--weak slds-truncate" title="Branch">Branch:</dt>
                 <dd class="slds-item--detail"><a href="{{ execution1.build.branch.get_absolute_url }}">{{ execution1.build.branch }}</a></dd>
                 <dt class="slds-item--label slds-text-color--weak slds-truncate" title="Commit">Commit:</dt>
-                <dd class="slds-item--detail"><a href="{{ execution1.build.commit.get_absolute_url }}">{{ execution1.build.commit }}</a></dd>
+                <dd class="slds-item--detail"><a href="{% url 'commit_detail' execution1.build.repo.owner execution1.build.repo.name execution1.build.commit %}">{{ execution1.build.commit }}</a></dd>
                 <dt class="slds-item--label slds-text-color--weak slds-truncate" title="Org">Org:</dt>
                 <dd class="slds-item--detail"><a href="{{ execution1.build.org.get_absolute_url }}">{{ execution1.build.org }}</a></dd>
               </dl>
@@ -51,7 +51,7 @@ Test Comparison for {{ execution1.build.repo }}
                 <dt class="slds-item--label slds-text-color--weak slds-truncate" title="Branch">Branch:</dt>
                 <dd class="slds-item--detail"><a href="{{ execution2.build.branch.get_absolute_url }}">{{ execution2.build.branch }}</a></dd>
                 <dt class="slds-item--label slds-text-color--weak slds-truncate" title="Commit">Commit:</dt>
-                <dd class="slds-item--detail"><a href="{{ execution2.build.commit.get_absolute_url }}">{{ execution2.build.commit }}</a></dd>
+                <dd class="slds-item--detail"><a href="{% url 'commit_detail' execution2.build.repo.owner execution2.build.repo.name execution2.build.commit %}">{{ execution2.build.commit }}</a></dd>
                 <dt class="slds-item--label slds-text-color--weak slds-truncate" title="Org">Org:</dt>
                 <dd class="slds-item--detail"><a href="{{ execution2.build.org.get_absolute_url }}">{{ execution2.build.org }}</a></dd>
               </dl>

--- a/mrbelvedereci/testresults/templates/testresults/build_flow_compare_to.html
+++ b/mrbelvedereci/testresults/templates/testresults/build_flow_compare_to.html
@@ -64,26 +64,35 @@
 
 {% block layout_body %}
 
-<form method="get">
+<article class="slds-card">
+
+    <div class="slds-card__body slds-p-around--small">
+        
+    <form method="get">
   {{ filter.form.as_table }}
   <button type="submit">Search</button>
 </form>
-
-
+</div>
+</article>
+<br/>
 <table class="slds-table slds-table--bordered slds-table--cell-buffer">
     <thead>
         <tr class="slds-text-title--caps">
             <th>Compare</th>
+            <th>Plan</th>
             <th>Branch</th>
             <th>Status</th>
+            <th>Start Date</th>
         </tr>
     </thead>
     <tbody>
         {% for bf in records %}
         <tr>
-            <td><a href="{% url 'build_flow_compare' %}?buildflow1={{build_flow.id}}&buildflow2={{bf.id}}">{{ bf }}</a></td>
+            <td class="slds-truncate"><a href="{% url 'build_flow_compare' %}?buildflow1={{build_flow.id}}&buildflow2={{bf.id}}">{{ bf.build.id }}: {{bf.flow}}</a></td>
+            <td>{{ bf.build.plan.name }}</td>
             <td>{{ bf.build.branch.name }}</td>
             <td>{{ bf.status }}</td>
+            <td>{{ bf.build.time_start }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/mrbelvedereci/testresults/utils.py
+++ b/mrbelvedereci/testresults/utils.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseForbidden
+from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 from mrbelvedereci.build.models import Build
 from mrbelvedereci.build.models import BuildFlow
@@ -9,7 +9,7 @@ def find_buildflow(request, build_id, flow):
     build = get_object_or_404(Build, id=build_id)
 
     if not build.plan.public and not request.user.is_staff:
-        raise HttpResponseForbidden()
+        raise PermissionDenied()
     query = {'build_id': build_id, 'flow': flow}
     if build.current_rebuild:
         query['rebuild_id'] = build.current_rebuild

--- a/mrbelvedereci/testresults/views.py
+++ b/mrbelvedereci/testresults/views.py
@@ -169,7 +169,10 @@ def build_flow_compare_to(request, build_id, flow):
     """ allows the user to select a build_flow to compare against the one they are on. """
     build_flow = find_buildflow(request, build_id, flow)
     # get a list of build_flows that could be compared to
-    possible_comparisons = BuildFlow.objects.filter(build__repo__exact=build_flow.build.repo).order_by('-time_end')
+    possible_comparisons = BuildFlow.objects.filter(
+        build__repo__exact=build_flow.build.repo,
+        status__in=['success','fail','error']
+    ).order_by('-time_end')
     # use a BuildFlowFilter to dynamically filter the queryset (and generate a form to display them)
     comparison_filter = BuildFlowFilter(request.GET, queryset=possible_comparisons)
     # LIMIT 10

--- a/mrbelvedereci/testresults/views.py
+++ b/mrbelvedereci/testresults/views.py
@@ -171,8 +171,8 @@ def build_flow_compare_to(request, build_id, flow):
     # get a list of build_flows that could be compared to
     possible_comparisons = BuildFlow.objects.filter(
         build__repo__exact=build_flow.build.repo,
-        status__in=['success','fail','error']
-    ).order_by('-time_end')
+        status__in=['success','fail','error'],
+    ).exclude(pk=build_flow.id).order_by('build')
     # use a BuildFlowFilter to dynamically filter the queryset (and generate a form to display them)
     comparison_filter = BuildFlowFilter(request.GET, queryset=possible_comparisons)
     # LIMIT 10


### PR DESCRIPTION
tests compare-to was not filtering out unfinished builds, causing a very wacky experience. this now uses a more sane selection of filters, doesn't present the current build as an option, and is generally a better page.