### PR TITLE
Add button for superusers to lock/unlock orgs

### DIFF
--- a/mrbelvedereci/build/tasks.py
+++ b/mrbelvedereci/build/tasks.py
@@ -98,9 +98,11 @@ def check_queued_build(build_id):
 
     else:
         # For persistent orgs, use the cache to lock the org
-        lock_id = 'mrbelvedereci-org-lock-{}'.format(org.id)
-        status = cache.add(lock_id, 'build-{}'.format(build_id),
-                           timeout=BUILD_TIMEOUT)
+        status = cache.add(
+            org.lock_id,
+            'build-{}'.format(build_id),
+            timeout=BUILD_TIMEOUT,
+        )
 
         if status is True:
             # Lock successful, run the build

--- a/mrbelvedereci/cumulusci/models.py
+++ b/mrbelvedereci/cumulusci/models.py
@@ -6,6 +6,7 @@ import os
 from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import ScratchOrgException
+from django.core.cache import cache
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
@@ -29,7 +30,25 @@ class Org(models.Model):
         org_config = json.loads(self.json)
 
         return OrgConfig(org_config)
-    
+
+    @property
+    def lock_id(self):
+        if not self.scratch:
+            return u'mrbelvedereci-org-lock-{}'.format(self.id)
+
+    def is_locked(self):
+        if not self.scratch:
+            return True if cache.get(self.lock_id) else False
+
+    def lock(self):
+        if not self.scratch:
+            cache.add(self.lock_id, 'manually locked')
+
+    def unlock(self):
+        if not self.scratch:
+            cache.delete(self.lock_id)
+
+
 class ScratchOrgInstance(models.Model):
     org = models.ForeignKey('cumulusci.Org', related_name='instances')
     build = models.ForeignKey('build.Build', related_name='scratch_orgs', null=True, blank=True)

--- a/mrbelvedereci/cumulusci/templates/cumulusci/org_detail.html
+++ b/mrbelvedereci/cumulusci/templates/cumulusci/org_detail.html
@@ -27,12 +27,27 @@
 
 {% block layout_header_buttons %}
 {% if not org.scratch %}
-      <a href="{{ org.get_absolute_url }}/login" target="_blank">
-        <button class="slds-button slds-button--brand">
-          Log In
-        </button>
-      </a>
-      {% endif %}
+{% if user.is_superuser %}
+{% if org.is_locked %}
+<a href="{{ org.get_absolute_url }}/unlock">
+  <button class="slds-button slds-button--destructive slds-m-horizontal--medium">
+    Unlock
+  </button>
+</a>
+{% else %}
+<a href="{{ org.get_absolute_url }}/lock">
+  <button class="slds-button slds-button--destructive slds-m-horizontal--medium">
+    Lock
+  </button>
+</a>
+{% endif %}
+{% endif %}
+<a href="{{ org.get_absolute_url }}/login" target="_blank">
+  <button class="slds-button slds-button--brand">
+    Log In
+  </button>
+</a>
+{% endif %}
 {% endblock %}
 
 {% block layout_body %}

--- a/mrbelvedereci/cumulusci/urls.py
+++ b/mrbelvedereci/cumulusci/urls.py
@@ -10,6 +10,16 @@ urlpatterns = [
         name='org_detail',
     ),
     url(
+        r'^(?P<org_id>\d+)/lock$',
+        views.org_lock,
+        name='org_lock',
+    ),
+    url(
+        r'^(?P<org_id>\d+)/unlock$',
+        views.org_unlock,
+        name='org_unlock',
+    ),
+    url(
         r'^(?P<org_id>\d+)/login$',
         views.org_login,
         name='org_login',

--- a/mrbelvedereci/cumulusci/views.py
+++ b/mrbelvedereci/cumulusci/views.py
@@ -1,6 +1,8 @@
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import user_passes_test
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404
+from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.shortcuts import get_object_or_404
@@ -24,6 +26,22 @@ def org_detail(request, org_id):
     } 
     return render(request, 'cumulusci/org_detail.html', context=context)
     
+@user_passes_test(lambda u: u.is_superuser)
+def org_lock(request, org_id):
+    org = get_object_or_404(Org, id=org_id)
+    if org.scratch:
+        raise HttpResponseForbidden('Scratch orgs may not be locked/unlocked')
+    org.lock()
+    return HttpResponseRedirect(org.get_absolute_url())
+
+@user_passes_test(lambda u: u.is_superuser)
+def org_unlock(request, org_id):
+    org = get_object_or_404(Org, id=org_id)
+    if org.scratch:
+        raise HttpResponseForbidden('Scratch orgs may not be locked/unlocked')
+    org.unlock()
+    return HttpResponseRedirect(org.get_absolute_url())
+
 @staff_member_required
 def org_login(request, org_id, instance_id=None):
     org = get_object_or_404(Org, id=org_id)


### PR DESCRIPTION
If user is superuser, and org is persistent, show a button to lock/unlock the org manually with no timeout.