### PR TITLE
Configure for coveralls.io test coverage reporting

### DIFF
--- a/app.json
+++ b/app.json
@@ -99,7 +99,7 @@
     "test": {
       "scripts": {
         "test-setup": "pip install --upgrade -r requirements/test.txt",
-        "test": "python manage.py test"
+        "test": "./heroku_ci.sh"
       },
       "env": {
         "DJANGO_SETTINGS_MODULE": "config.settings.test",

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -39,9 +39,20 @@ CACHES = {
     }
 }
 
+# Add django_nose to INSTALLED_APPS
+INSTALLED_APPS = INSTALLED_APPS + (
+    'django_nose',
+)
+
 # TESTING
 # ------------------------------------------------------------------------------
-TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+NOSE_ARGS = [
+    '--with-tap',
+    '--tap-stream',
+    '--with-coverage',
+    '--cover-package=mrbelvedereci',
+]
 
 
 # PASSWORD HASHING

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -40,9 +40,9 @@ CACHES = {
 }
 
 # Add django_nose to INSTALLED_APPS
-INSTALLED_APPS = INSTALLED_APPS + [
+INSTALLED_APPS = INSTALLED_APPS + (
     'django_nose',
-]
+)
 
 # TESTING
 # ------------------------------------------------------------------------------

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -40,9 +40,9 @@ CACHES = {
 }
 
 # Add django_nose to INSTALLED_APPS
-INSTALLED_APPS = INSTALLED_APPS + (
+INSTALLED_APPS = INSTALLED_APPS + [
     'django_nose',
-)
+]
 
 # TESTING
 # ------------------------------------------------------------------------------

--- a/heroku_ci.sh
+++ b/heroku_ci.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # This script runs the tests on Heroku CI
 
-#git clone -b "$HEROKU_TEST_RUN_BRANCH" --single-branch https://github.com/SalesforceFoundation/mrbelvedereci_checkout 
-#cd mrbelvedereci_checkout
-#git reset --hard $HEROKU_TEST_RUN_COMMIT_VERSION
-coverage run --source=mrbelvedereci manage.py test
-#nosetests --with-tap --tap-stream --with-coverage --cover-package=cumulusci
-#coveralls
+git clone -b "$HEROKU_TEST_RUN_BRANCH" --single-branch https://github.com/SalesforceFoundation/mrbelvedereci_checkout 
+cd mrbelvedereci_checkout
+git reset --hard $HEROKU_TEST_RUN_COMMIT_VERSION
+export DJANGO_SETTINGS_MODULE=config.settings.test
+python manage.py test
+coveralls

--- a/heroku_ci.sh
+++ b/heroku_ci.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# This script runs the tests on Heroku CI
+
+#git clone -b "$HEROKU_TEST_RUN_BRANCH" --single-branch https://github.com/SalesforceFoundation/mrbelvedereci_checkout 
+#cd mrbelvedereci_checkout
+#git reset --hard $HEROKU_TEST_RUN_COMMIT_VERSION
+coverage run --source=mrbelvedereci manage.py test
+#nosetests --with-tap --tap-stream --with-coverage --cover-package=cumulusci
+#coveralls

--- a/heroku_ci.sh
+++ b/heroku_ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script runs the tests on Heroku CI
 
-git clone -b "$HEROKU_TEST_RUN_BRANCH" --single-branch https://github.com/SalesforceFoundation/mrbelvedereci_checkout 
+git clone -b "$HEROKU_TEST_RUN_BRANCH" --single-branch https://github.com/SalesforceFoundation/mrbelvedereci mrbelvedereci_checkout 
 cd mrbelvedereci_checkout
 git reset --hard $HEROKU_TEST_RUN_COMMIT_VERSION
 export DJANGO_SETTINGS_MODULE=config.settings.test

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,6 +8,7 @@ flake8==3.2.1 # pyup: != 2.6.0
 django-test-plus==1.0.16
 factory_boy==2.7.0
 
-# pytest
-pytest-django==3.1.1
-pytest-sugar==0.7.1
+# nosetests with support for TAP and coveralls
+django_nose==1.4.5
+nose-tap==1.9
+coveralls==1.2.0


### PR DESCRIPTION
This branch changes the test runner to use nosetests instead of py.test since django_nose makes it far easier to pass the custom command line options we need to pass to the test runner to enable TAP output which is parsed by Heroku CI and coverage collection from django tests.  Or, at least this was the easiest way I could sort out this morning for how to do it :)