### PR TITLE
Manually lock/unlock org

### DIFF
--- a/mrbelvedereci/build/tasks.py
+++ b/mrbelvedereci/build/tasks.py
@@ -98,9 +98,11 @@ def check_queued_build(build_id):
 
     else:
         # For persistent orgs, use the cache to lock the org
-        lock_id = 'mrbelvedereci-org-lock-{}'.format(org.id)
-        status = cache.add(lock_id, 'build-{}'.format(build_id),
-                           timeout=BUILD_TIMEOUT)
+        status = cache.add(
+            org.lock_id,
+            'build-{}'.format(build_id),
+            timeout=BUILD_TIMEOUT,
+        )
 
         if status is True:
             # Lock successful, run the build

--- a/mrbelvedereci/cumulusci/forms.py
+++ b/mrbelvedereci/cumulusci/forms.py
@@ -1,0 +1,53 @@
+from crispy_forms.bootstrap import FormActions
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout
+from crispy_forms.layout import Submit
+from django import forms
+
+
+class OrgLockForm(forms.Form):
+
+    def __init__(self, *args, **kwargs):
+        super(OrgLockForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_class = 'form-vertical'
+        self.helper.form_id = 'org-lock-form'
+        self.helper.form_method = 'post'
+        self.helper.layout = Layout(
+            FormActions(
+                Submit(
+                    'action',
+                    'Cancel',
+                    css_class='slds-button slds-button--neutral',
+                ),
+                Submit(
+                    'action',
+                    'Lock',
+                    css_class='slds-button slds-button--destructive',
+                ),
+            ),
+        )
+
+
+class OrgUnlockForm(forms.Form):
+
+    def __init__(self, *args, **kwargs):
+        super(OrgUnlockForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.form_class = 'form-vertical'
+        self.helper.form_id = 'org-unlock-form'
+        self.helper.form_method = 'post'
+        self.helper.layout = Layout(
+            FormActions(
+                Submit(
+                    'action',
+                    'Cancel',
+                    css_class='slds-button slds-button--neutral',
+                ),
+                Submit(
+                    'action',
+                    'Unlock',
+                    css_class='slds-button slds-button--destructive',
+                ),
+            ),
+        )

--- a/mrbelvedereci/cumulusci/models.py
+++ b/mrbelvedereci/cumulusci/models.py
@@ -36,6 +36,7 @@ class Org(models.Model):
         if not self.scratch:
             return u'mrbelvedereci-org-lock-{}'.format(self.id)
 
+    @property
     def is_locked(self):
         if not self.scratch:
             return True if cache.get(self.lock_id) else False

--- a/mrbelvedereci/cumulusci/models.py
+++ b/mrbelvedereci/cumulusci/models.py
@@ -6,6 +6,7 @@ import os
 from cumulusci.core.config import ScratchOrgConfig
 from cumulusci.core.config import OrgConfig
 from cumulusci.core.exceptions import ScratchOrgException
+from django.core.cache import cache
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
@@ -29,7 +30,25 @@ class Org(models.Model):
         org_config = json.loads(self.json)
 
         return OrgConfig(org_config)
-    
+
+    @property
+    def lock_id(self):
+        if not self.scratch:
+            return u'mrbelvedereci-org-lock-{}'.format(self.id)
+
+    def is_locked(self):
+        if not self.scratch:
+            return True if cache.get(self.lock_id) else False
+
+    def lock(self):
+        if not self.scratch:
+            cache.add(self.lock_id, 'manually locked')
+
+    def unlock(self):
+        if not self.scratch:
+            cache.delete(self.lock_id)
+
+
 class ScratchOrgInstance(models.Model):
     org = models.ForeignKey('cumulusci.Org', related_name='instances')
     build = models.ForeignKey('build.Build', related_name='scratch_orgs', null=True, blank=True)

--- a/mrbelvedereci/cumulusci/templates/cumulusci/org_detail.html
+++ b/mrbelvedereci/cumulusci/templates/cumulusci/org_detail.html
@@ -27,12 +27,27 @@
 
 {% block layout_header_buttons %}
 {% if not org.scratch %}
-      <a href="{{ org.get_absolute_url }}/login" target="_blank">
-        <button class="slds-button slds-button--brand">
-          Log In
-        </button>
-      </a>
-      {% endif %}
+{% if user.is_superuser %}
+{% if org.is_locked %}
+<a href="{{ org.get_absolute_url }}/unlock">
+  <button class="slds-button slds-button--destructive slds-m-horizontal--medium">
+    Unlock
+  </button>
+</a>
+{% else %}
+<a href="{{ org.get_absolute_url }}/lock">
+  <button class="slds-button slds-button--destructive slds-m-horizontal--medium">
+    Lock
+  </button>
+</a>
+{% endif %}
+{% endif %}
+<a href="{{ org.get_absolute_url }}/login" target="_blank">
+  <button class="slds-button slds-button--brand">
+    Log In
+  </button>
+</a>
+{% endif %}
 {% endblock %}
 
 {% block layout_body %}

--- a/mrbelvedereci/cumulusci/templates/cumulusci/org_lock.html
+++ b/mrbelvedereci/cumulusci/templates/cumulusci/org_lock.html
@@ -1,0 +1,32 @@
+{% extends 'layout_full.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block layout_header_text %}Lock Org{% endblock %}
+
+{% block layout_body %}
+
+<h3 class="slds-text-heading--medium slds-m-bottom--medium">
+  Are you sure you want to lock this org? This may prevent some queued builds from running.
+</h3>
+<div class="slds-box slds-m-bottom--medium">
+  <table class="slds-table slds-no-row-hover">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Repository</th>
+      </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>{{ org.name }}</td>
+      <td>{{ org.repo }}</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+    {{ form.errors }}
+      {% crispy form form.helper %}
+
+{% endblock %}

--- a/mrbelvedereci/cumulusci/templates/cumulusci/org_lock.html
+++ b/mrbelvedereci/cumulusci/templates/cumulusci/org_lock.html
@@ -10,17 +10,21 @@
   Are you sure you want to lock this org? This may prevent some queued builds from running.
 </h3>
 <div class="slds-box slds-m-bottom--medium">
-  <table class="slds-table slds-no-row-hover">
+  <table class="slds-table slds-table--cell-buffer">
     <thead>
-      <tr>
-        <th>Name</th>
-        <th>Repository</th>
+      <tr class="slds-text-title--caps">
+        <th scope="col">
+          <div class="slds-truncate" title="Org Name">Org Name</div>
+        </th>
+        <th scope="col">
+          <div class="slds-truncate" title="Repository">Repository</div>
+        </th>
       </tr>
     </thead>
     <tbody>
     <tr>
-      <td>{{ org.name }}</td>
-      <td>{{ org.repo }}</td>
+      <td data-label="Org Name">{{ org.name }}</td>
+      <td data-label="Repository">{{ org.repo }}</td>
     </tr>
     </tbody>
   </table>

--- a/mrbelvedereci/cumulusci/templates/cumulusci/org_unlock.html
+++ b/mrbelvedereci/cumulusci/templates/cumulusci/org_unlock.html
@@ -1,0 +1,32 @@
+{% extends 'layout_full.html' %}
+
+{% load crispy_forms_tags %}
+
+{% block layout_header_text %}Unlock Org{% endblock %}
+
+{% block layout_body %}
+
+<h3 class="slds-text-heading--medium slds-m-bottom--medium">
+  Are you sure you want to unlock this org? This may result in multiple builds using this org at the same time.
+</h3>
+<div class="slds-box slds-m-bottom--medium">
+  <table class="slds-table slds-no-row-hover">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Repository</th>
+      </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>{{ org.name }}</td>
+      <td>{{ org.repo }}</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+    {{ form.errors }}
+      {% crispy form form.helper %}
+
+{% endblock %}

--- a/mrbelvedereci/cumulusci/templates/cumulusci/org_unlock.html
+++ b/mrbelvedereci/cumulusci/templates/cumulusci/org_unlock.html
@@ -10,17 +10,21 @@
   Are you sure you want to unlock this org? This may result in multiple builds using this org at the same time.
 </h3>
 <div class="slds-box slds-m-bottom--medium">
-  <table class="slds-table slds-no-row-hover">
+  <table class="slds-table slds-table--cell-buffer">
     <thead>
-      <tr>
-        <th>Name</th>
-        <th>Repository</th>
+      <tr class="slds-text-title--caps">
+        <th scope="col">
+          <div class="slds-truncate" title="Org Name">Org Name</div>
+        </th>
+        <th scope="col">
+          <div class="slds-truncate" title="Repository">Repository</div>
+        </th>
       </tr>
     </thead>
     <tbody>
     <tr>
-      <td>{{ org.name }}</td>
-      <td>{{ org.repo }}</td>
+      <td data-label="Org Name">{{ org.name }}</td>
+      <td data-label="Repository">{{ org.repo }}</td>
     </tr>
     </tbody>
   </table>

--- a/mrbelvedereci/cumulusci/urls.py
+++ b/mrbelvedereci/cumulusci/urls.py
@@ -10,6 +10,16 @@ urlpatterns = [
         name='org_detail',
     ),
     url(
+        r'^(?P<org_id>\d+)/lock$',
+        views.org_lock,
+        name='org_lock',
+    ),
+    url(
+        r'^(?P<org_id>\d+)/unlock$',
+        views.org_unlock,
+        name='org_unlock',
+    ),
+    url(
         r'^(?P<org_id>\d+)/login$',
         views.org_login,
         name='org_login',

--- a/mrbelvedereci/cumulusci/views.py
+++ b/mrbelvedereci/cumulusci/views.py
@@ -1,6 +1,8 @@
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import user_passes_test
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404
+from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.shortcuts import get_object_or_404
@@ -24,6 +26,22 @@ def org_detail(request, org_id):
     } 
     return render(request, 'cumulusci/org_detail.html', context=context)
     
+@user_passes_test(lambda u: u.is_superuser)
+def org_lock(request, org_id):
+    org = get_object_or_404(Org, id=org_id)
+    if org.scratch:
+        raise HttpResponseForbidden('Scratch orgs may not be locked/unlocked')
+    org.lock()
+    return HttpResponseRedirect(org.get_absolute_url())
+
+@user_passes_test(lambda u: u.is_superuser)
+def org_unlock(request, org_id):
+    org = get_object_or_404(Org, id=org_id)
+    if org.scratch:
+        raise HttpResponseForbidden('Scratch orgs may not be locked/unlocked')
+    org.unlock()
+    return HttpResponseRedirect(org.get_absolute_url())
+
 @staff_member_required
 def org_login(request, org_id, instance_id=None):
     org = get_object_or_404(Org, id=org_id)

--- a/mrbelvedereci/cumulusci/views.py
+++ b/mrbelvedereci/cumulusci/views.py
@@ -27,8 +27,9 @@ def org_detail(request, org_id):
         'instances': instances,
     } 
     return render(request, 'cumulusci/org_detail.html', context=context)
-    
-def org_lock_unlock(request, org_id, action):
+
+# not wired to urlconf; called by org_lock and org_unlock
+def _org_lock_unlock(request, org_id, action):
     org = get_object_or_404(Org, id=org_id)
     if org.scratch:
         raise HttpResponseForbidden('Scratch orgs may not be locked/unlocked')
@@ -52,11 +53,11 @@ def org_lock_unlock(request, org_id, action):
 
 @user_passes_test(lambda u: u.is_superuser)
 def org_lock(request, org_id):
-    return org_lock_unlock(request, org_id, 'lock')
+    return _org_lock_unlock(request, org_id, 'lock')
 
 @user_passes_test(lambda u: u.is_superuser)
 def org_unlock(request, org_id):
-    return org_lock_unlock(request, org_id, 'unlock')
+    return _org_lock_unlock(request, org_id, 'unlock')
 
 @staff_member_required
 def org_login(request, org_id, instance_id=None):

--- a/mrbelvedereci/notification/views.py
+++ b/mrbelvedereci/notification/views.py
@@ -79,7 +79,7 @@ def add_plan_notification(request):
 
 @login_required
 def delete_branch_notification(request, pk):
-    return delete_notification(
+    return _delete_notification(
         request,
         BranchNotification.objects.get(pk=pk),
     )
@@ -87,7 +87,7 @@ def delete_branch_notification(request, pk):
 
 @login_required
 def delete_plan_notification(request, pk):
-    return delete_notification(
+    return _delete_notification(
         request,
         PlanNotification.objects.get(pk=pk),
     )
@@ -95,13 +95,13 @@ def delete_plan_notification(request, pk):
 
 @login_required
 def delete_repository_notification(request, pk):
-    return delete_notification(
+    return _delete_notification(
         request,
         RepositoryNotification.objects.get(pk=pk),
     )
 
-
-def delete_notification(request, notification):
+# not wired to urlconf; called by delete_*_notification functions
+def _delete_notification(request, notification):
     if request.user != notification.user:
         return HttpResponseForbidden()
     if request.method == 'POST':


### PR DESCRIPTION
Continuation of https://github.com/SalesforceFoundation/mrbelvedereci/pull/112

Now the (super)user is sent to a confirmation form. This ensures we send a POST to modify the lock state, and CSRF protection is taken care of by crispy-forms.