### PR TITLE
Update the Gemfile to also require json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'page-object'
 gem 'rspec'
 gem 'cucumber'
 gem 'restforce'
+gem 'json'
 gem 'SFDO-API'
 gem 'pry', require: false
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,11 +97,15 @@ PLATFORMS
 DEPENDENCIES
   SFDO-API
   cucumber
+  json
   page-object
   pry
   restforce
   rspec
   rubocop
 
+RUBY VERSION
+   ruby 2.2.6p396
+
 BUNDLED WITH
-   1.13.6
+   1.14.6


### PR DESCRIPTION
The cci tasks that run browser tests first load the Gemfile from the tests.  In theory this is to allow individual projects to define additional gem dependencies.  The problem is that this happens in dyno runtime rather than slug compilation.  As a result, if any dependency in the tree generated from the Gemfile requires compilation with gcc it will fail.

It appears the core http gem in ruby is now requiring json which it wasn't before.  That caused all browser test builds to fail.  This branch just adds the json gem to mrbelvedereci's Gemfile so it's installed during slug compilation.  I then ran `bundle install` and committed the resulting Gemfile.lock