### PR TITLE
remove SFDX plugin version info from about page

### DIFF
--- a/mrbelvedereci/templates/pages/about.html
+++ b/mrbelvedereci/templates/pages/about.html
@@ -16,7 +16,6 @@
       <tr><th>Django version</th><td>{{ DJANGO_VERSION }}</td></tr>
       <tr><th>Python version</th><td>{{ PYTHON_VERSION }}</td></tr>
       <tr><th>Salesforce DX CLI version</th><td>{{ SFDX_CLI_VERSION }}</td></tr>
-      <tr><th>Salesforce DX plugin version</th><td>{{ SFDX_PLUGIN_VERSION }}</td></tr>
       <tr><th>CumulusCI version</th><td>{{ CUMULUSCI_VERSION }}</td></tr>
       <tr><th>HEROKU_APP_ID</th><td>{{ HEROKU_APP_ID }}</td></tr>
       <tr><th>HEROKU_APP_NAME</th><td>{{ HEROKU_APP_NAME }}</td></tr>

--- a/mrbelvedereci/views.py
+++ b/mrbelvedereci/views.py
@@ -32,10 +32,6 @@ class AboutView(TemplateView):
         match = re.match(r'sfdx-cli/(\d+.\d+.\d+)-.+', out)
         if match:
             context['SFDX_CLI_VERSION'] = match.group(1)
-        out = subprocess.check_output(['sfdx', 'plugins'])
-        match = re.match(r'salesforcedx (\d+.\d+.\d+)', out)
-        if match:
-            context['SFDX_PLUGIN_VERSION'] = match.group(1)
 
         # cumulusci
         context['CUMULUSCI_VERSION'] = get_installed_version('cumulusci')


### PR DESCRIPTION
No longer listed by `sfdx plugins`