### PR TITLE
retry getting org a few times if sfdx fails to create scratch org

### DIFF
--- a/mrbelvedereci/build/models.py
+++ b/mrbelvedereci/build/models.py
@@ -274,7 +274,7 @@ class Build(models.Model):
         return project_config
 
     def get_org(self, project_config, retries=3):
-        logger = init_logger(self)
+        self.logger = init_logger(self)
         attempt = 1
         while True:
             try:
@@ -285,8 +285,8 @@ class Build(models.Model):
                     e.message.startswith(FAILED_TO_CREATE_SCRATCH_ORG) and
                     attempt <= retries
                 ):
-                    logger.warning(e.message)
-                    logger.info('Retrying create scratch org ' +
+                    self.logger.warning(e.message)
+                    self.logger.info('Retrying create scratch org ' +
                         '(retry {} of {})'.format(attempt, retries))
                     attempt += 1
                     continue

--- a/mrbelvedereci/build/models.py
+++ b/mrbelvedereci/build/models.py
@@ -16,6 +16,7 @@ from cumulusci.core.config import FAILED_TO_CREATE_SCRATCH_ORG
 from cumulusci.core.exceptions import ApexTestException
 from cumulusci.core.exceptions import BrowserTestFailure
 from cumulusci.core.exceptions import FlowNotFoundError
+from cumulusci.core.exceptions import ScratchOrgException
 from cumulusci.core.utils import import_class
 from cumulusci.salesforce_api.exceptions import MetadataComponentFailure
 from django.conf import settings

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -43,7 +43,7 @@ django-rq-wrapper>=1.4
 django-rq-scheduler>=1.1.1
 
 # CumulusCI
-cumulusci==2.0.0b68
+cumulusci==2.0.0b69
 
 # Salesforce Lightning Design System for Django
 django-slds


### PR DESCRIPTION
Since this isn't an exception from the flow we can't catch it in the same way that we do for e.g. Apex test failures. So instead I retry getting the org a few times before giving up, all within the build.

NOTE: depends on https://github.com/SalesforceFoundation/CumulusCI/pull/485

Fixes #104 